### PR TITLE
ADD vpc endpoint for SES 

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -188,10 +188,6 @@ resource "aws_lambda_function" "gt_pipeline" {
   timeout       = 300
   memory_size   = 512
 
-  vpc_config {
-    subnet_ids         = var.public_subnet_ids
-    security_group_ids = [aws_security_group.gt_lambda_sg.id]
-  }
 
   environment {
     variables = {


### PR DESCRIPTION
## Description
after looking at the cloudwatch logs the alert email was not sending so I made a new resource , a vpc endpoint allowing for the lambda inside the vpc to access the ses service

## Files changed/added
*terraform/main.tf*
